### PR TITLE
Add error template

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,27 @@
+{% extends "templates/error.html" %}
+
+{% block error_detail %}
+{% if status_code == 403 %}
+<style>
+	.info {
+  		color: #fc8703;
+  		background-color: #f2f2f3;
+		
+		max-width: 640px;
+		padding: 30px;
+		margin: 0 auto;
+		overflow: hidden;
+		font-size: 17px;
+	}
+</style>
+<div class="error">
+	<div class="info">
+		<i class="fa fa-info-circle"></i>
+	  	If your email address has <b>NOT</b> been added to the list of allowed users for this hub, please <b>contact</b> the hub administrators.
+	</div>
+</div>
+{% else %}
+{{ super() }}
+{% endif %}
+
+{% endblock error_detail %}


### PR DESCRIPTION
I wasn't able to test this following the instructions in the readme :( I was stuck into a redirect loop.
But I tested this with a simpler config and just this error template and a 403 Error looks like this:

![forbidden-err-msg](https://user-images.githubusercontent.com/7579677/101170497-3a158980-3647-11eb-86fe-ea792edcea12.png)

ref: https://github.com/2i2c-org/pilot-hubs/issues/46