### PR TITLE
Add note about matching a branch name with a hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ will be deployed to the other hubs too after around 5min.
    ```bash
    git branch git push -d <remote> staging
    ```
+
+**NOTE**
+
+Note that creating a branch in this repository with a name that matches the name of a hub in the [2i2c hubs repository](https://github.com/2i2c-org/infrastructure/tree/HEAD/config/clusters), then the changes in this branch will be reflected on that hub. This can be used either for testing (if this branch gets deleted once the changes have been merged into the main branch), or for having specific hompage customizations per hub.


### PR DESCRIPTION
As suggested by @damianavila in https://github.com/2i2c-org/pilot-homepage/pull/6#discussion_r771560144.

This made me realize that we probably need to handle the branch name as a combination of `<cluster_name>-<hub_name>` otherwise we can get into name clashes:
https://github.com/2i2c-org/infrastructure/blob/e0e6d3f66674afa7ea1001cce5fd0bc907c78d51/deployer/hub.py#L403-L407