### PR TITLE
Add a "try another account" button

### DIFF
--- a/templates/error.html
+++ b/templates/error.html
@@ -22,7 +22,7 @@
 	</div>
 	<div class="text-center">
 		<a role="button" class='btn btn-jupyter' href='{{base_url}}/logout'>
-		Click to retry login
+		Tap to try a different account
 		</a>
 	</div>
 </div>

--- a/templates/error.html
+++ b/templates/error.html
@@ -17,7 +17,12 @@
 <div class="error">
 	<div class="info">
 		<i class="fa fa-info-circle"></i>
-	  	Looks like you have <b>NOT</b> been added to the list of allowed users for this hub. Please contact the hub administrators.
+		Looks like you have <b>NOT</b> been added to the list of allowed users for this hub. Please contact the hub administrators.
+	</div>
+	<div class="text-center">
+		<a role="button" class='btn btn-jupyter' href='{{base_url}}/logout'>
+		Click to retry login
+		</a>
 	</div>
 </div>
 {% else %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -10,6 +10,7 @@
 		max-width: 640px;
 		padding: 30px;
 		margin: 0 auto;
+		margin-bottom: 30px;
 		overflow: hidden;
 		font-size: 17px;
 	}


### PR DESCRIPTION
This adds a button that redirects to the `hub/logout` endpoint if clicked, which will redirect back to the login page and allow the use of a different account.
![try-other-account](https://user-images.githubusercontent.com/7579677/152522660-8a73d104-b96f-4ad7-aa9c-1b02354b5b53.gif)

Fixes https://github.com/2i2c-org/infrastructure/issues/973
