### PR TITLE
Show interface selector on home page

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -17,7 +17,7 @@ c.Authenticator.admin_users = [
 
 c.JupyterHub.template_vars = {
     'custom': {
-        "homepage": {"interface_selector": True},
+        "interface_selector": True,
         'org': {
             'name': 'University of Foo',
             'logo_url': 'https://jupyter.org/assets/nav_logo.svg',

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -17,6 +17,7 @@ c.Authenticator.admin_users = [
 
 c.JupyterHub.template_vars = {
     'custom': {
+        "homepage": {"interface_selector": True},
         'org': {
             'name': 'University of Foo',
             'logo_url': 'https://jupyter.org/assets/nav_logo.svg',

--- a/templates/login.html
+++ b/templates/login.html
@@ -29,11 +29,7 @@
   </div>
   </div>
   <div class="login-container text-center">
-    {% if next %}
-    <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-      Log in to continue
-    </a>
-    {% else %}
+    {% if ('homepage' in custom and custom.homepage["interface_selector"]) and (not next or next == "%2Fhub%2F") %}
     <form class="form-inline">
       <div class="form-group interface-selector">
         <label>After logging in, open: </label>
@@ -48,11 +44,12 @@
         </label>
       </div>
     </form>
-    <a role="button"
-       id="login-button"
-       class='btn btn-jupyter btn-lg'
-       href='{{authenticator_login_url}}'>
-        Log in to start
+    <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
+      Log in to start
+    </a>
+    {% else %}
+    <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
+      Log in to continue
     </a>
     {% endif %}
   </div>

--- a/templates/login.html
+++ b/templates/login.html
@@ -29,7 +29,7 @@
   </div>
   </div>
   <div class="login-container text-center">
-    {% if ('homepage' in custom and custom.homepage["interface_selector"]) and (not next or next == "%2Fhub%2F") %}
+    {% if "interface_selector" in custom and custom["interface_selector"] and (not next or next == "%2Fhub%2F") %}
     <form class="form-inline">
       <div class="form-group interface-selector">
         <label>After logging in, open: </label>


### PR DESCRIPTION
If you just go to the hub (like jupyter.utoronto.ca), it actually
redirects you to https://jupyter.utoronto.ca/, it actually
redirects you to https://jupyter.utoronto.ca/hub/login?next=%2Fhub%2F.
So the 'next' URL is in fact set, and so we never see the
interface selector!

We don't want the selector on all hubs actually, as some might not
have RStudio nor Classic Notebook. So it's now explicitly
enableable on a per cluster basis.

Ref https://2i2c.freshdesk.com/a/tickets/97