### PR TITLE
Don't treat /next/ as valid hub target

### DIFF
--- a/extra-assets/js/login.js
+++ b/extra-assets/js/login.js
@@ -18,7 +18,8 @@ $(function() {
     redirectIfNeeded();
     // if next query param is presentm just do nothing
     const nextPresent = new URL(document.location).searchParams.get('next');
-    if (!nextPresent) {
+    // /hub/ being next should be treated same as no next present
+    if (!nextPresent || nextPresent === "/hub/") {
         setInterface($("input[name='interface']:checked").val());
 
         $("input[name='interface']").change(function() {


### PR DESCRIPTION
It just means redirect to hub home page, doesn't
mean anything.

Follow-up to https://github.com/2i2c-org/default-hub-homepage/pull/11

Fixes https://2i2c.freshdesk.com/a/tickets/199

I've currently deployed this to the utoronto hubs by having a 
`utoronto-staging` and `utoronto-prod` branches here.

Once merged, we should remove both those branches so
the utoronto hub can also deploy from master.