### PR TITLE
Allow for multiple separate links via custom_html

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -32,15 +32,18 @@ c.JupyterHub.template_vars = {
         },
         'operated_by': {
             'name': 'Operating Org',
-            'url': 'https://2i2c.org'
+            'url': 'https://2i2c.org',
+            'custom_html': '',
         },
         'funded_by': {
-            'name': 'Funding Org',
-            'url': 'https://2i2c.org'
+            'name': '',
+            'url': '',
+            'custom_html': 'Funding <i>Org</i>',
         },
         'designed_by': {
-            'name': '2i2c',
-            'url': 'https://2i2c.org'
+            'name': 'Funding Org',
+            'url': 'https://2i2c.org',
+            'custom_html': '',
         }
     }
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -23,9 +23,23 @@
         title='hub logo' />
     </a>
   <div id="operated-by">
+      {%- if custom.operated_by.custom_html %}
+      Operated by: {{ custom.operated_by.custom_html | safe }} |
+      {%- else %}
       Operated by: <a href="{{ custom.operated_by.url }}">{{ custom.operated_by.name }}</a> |
+      {%- endif %}
+
+      {%- if custom.funded_by.custom_html %}
+      Funded by: {{ custom.funded_by.custom_html | safe }} |
+      {%- else %}
       Funded by: <a href="{{ custom.funded_by.url }}">{{ custom.funded_by.name }}</a> |
+      {%- endif %}
+
+      {%- if custom.designed_by.custom_html %}
+      Designed by: {{ custom.designed_by.custom_html | safe }}
+      {%- else %}
       Designed by: <a href="{{ custom.designed_by.url }}">{{ custom.designed_by.name }}</a>
+      {%- endif %}
   </div>
   </div>
   <div class="login-container text-center">


### PR DESCRIPTION
This is a feature to help me able to link to multiple funding organizations etc as relevant in https://github.com/2i2c-org/infrastructure/issues/2897. If approved, I'll use it to produce something that looks like this:

![image](https://github.com/2i2c-org/default-hub-homepage/assets/3837114/74c640b1-89df-4118-b655-91bb8a16f350)

via configuration like this:

```python
        'funded_by': {
            'name': '',
            'url': '',
            'custom_html': '<a href="https://www.dfg.de/">DFG</a>, <a href="https://www.cessda.eu/">CESSDA</a>, <a href="https://www.gesis.org/">GESIS</a>, FKZ/Project number <a href="https://gepris.dfg.de/gepris/projekt/460234259?language=en">460234259</a>',
        },
```