### PR TITLE
Have a branch to support homepages with username and password prompts

### DIFF
--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -6,9 +6,11 @@
     margin-top: 32px;
 }
 
-#login-button {
-    margin-top: 32px;
+#login-main {
+    display: table;
+    height: 60vh;
 }
+
 #operated-by {
     margin-top: 8px;
     color: darkgrey;

--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -6,11 +6,6 @@
     margin-top: 32px;
 }
 
-#login-main {
-    display: table;
-    height: 60vh;
-}
-
 #operated-by {
     margin-top: 8px;
     color: darkgrey;

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,13 +15,16 @@
 {% endblock %}
 
 {% block main %}
-<div class="container login-header" id="home" data-authenticator-login-url="{{authenticator_login_url}}">
+<div class="container login-header" id="home">
   <div class="text-center">
     <p class="hub-login-text">The 2i2c JupyterHub for <a href="{{ custom.org.url }}">{{ custom.org.name }}</a></p><br />
     <a href="{{ custom.org.url }}">
       <img src="{{ custom.org.logo_url }}" alt="{{ custom.org.name }} logo" class='hub-logo'
         title='hub logo' />
     </a>
+  {% block login %}
+  {{ super() }}
+  {% endblock %}
   <div id="operated-by">
       {%- if custom.operated_by.custom_html %}
       Operated by: {{ custom.operated_by.custom_html | safe }} |
@@ -41,43 +44,6 @@
       Designed by: <a href="{{ custom.designed_by.url }}">{{ custom.designed_by.name }}</a>
       {%- endif %}
   </div>
-  </div>
-  <div class="login-container text-center">
-    {% if "interface_selector" in custom and custom["interface_selector"] and (not next or next == "%2Fhub%2F") %}
-    <form class="form-inline">
-      <div class="form-group interface-selector">
-        <label>After logging in, open: </label>
-        <label class="radio-inline">
-          <input type="radio" name="interface" value="tree"
-                 {% if "default_url" not in custom or custom["default_url"] == "/tree" %}
-                 checked
-                 {% endif %}
-                 >Jupyter Notebook
-        </label>
-        <label class="radio-inline">
-          <input type="radio" name="interface" value="rstudio"
-                 {% if "default_url" in custom and custom["default_url"] == "/rstudio" %}
-                 checked
-                 {% endif %}
-                 >RStudio
-        </label>
-        <label class="radio-inline">
-          <input type="radio" name="interface" value="lab"
-                 {% if "default_url" in custom and custom["default_url"] == "/lab" %}
-                 checked
-                 {% endif %}
-                 >JupyterLab
-        </label>
-      </div>
-    </form>
-    <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-      Log in to start
-    </a>
-    {% else %}
-    <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-      Log in to continue
-    </a>
-    {% endif %}
   </div>
 
   <div class="col-md-8 col-md-offset-2 details">

--- a/templates/login.html
+++ b/templates/login.html
@@ -42,11 +42,10 @@
       {%- endif %}
   </div>
   </div>
-  <div class="login-container text-center">
-    {% block login %}
-    {{ super() }}
-    {% endblock %}
   </div>
+  {% block login %}
+  {{ super() }}
+  {% endblock %}
 
   <div class="col-md-8 col-md-offset-2 details">
     <div class="col-md-6">

--- a/templates/login.html
+++ b/templates/login.html
@@ -22,9 +22,6 @@
       <img src="{{ custom.org.logo_url }}" alt="{{ custom.org.name }} logo" class='hub-logo'
         title='hub logo' />
     </a>
-  {% block login %}
-  {{ super() }}
-  {% endblock %}
   <div id="operated-by">
       {%- if custom.operated_by.custom_html %}
       Operated by: {{ custom.operated_by.custom_html | safe }} |
@@ -44,6 +41,11 @@
       Designed by: <a href="{{ custom.designed_by.url }}">{{ custom.designed_by.name }}</a>
       {%- endif %}
   </div>
+  </div>
+  <div class="login-container text-center">
+    {% block login %}
+    {{ super() }}
+    {% endblock %}
   </div>
 
   <div class="col-md-8 col-md-offset-2 details">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,6 +1,5 @@
 {% extends "templates/login.html" %}
 
-
 {% block nav_bar %}
 {% endblock %}
 
@@ -15,6 +14,12 @@
 {% endblock %}
 
 {% block main %}
+<style>
+  #login-main {
+    display: table;
+    height: 60vh;
+  }
+</style>
 <div class="container login-header" id="home">
   <div class="text-center">
     <p class="hub-login-text">The 2i2c JupyterHub for <a href="{{ custom.org.url }}">{{ custom.org.name }}</a></p><br />

--- a/templates/login.html
+++ b/templates/login.html
@@ -22,30 +22,32 @@
       <img src="{{ custom.org.logo_url }}" alt="{{ custom.org.name }} logo" class='hub-logo'
         title='hub logo' />
     </a>
-  <div id="operated-by">
-      {%- if custom.operated_by.custom_html %}
-      Operated by: {{ custom.operated_by.custom_html | safe }} |
-      {%- else %}
-      Operated by: <a href="{{ custom.operated_by.url }}">{{ custom.operated_by.name }}</a> |
-      {%- endif %}
+    <div id="operated-by">
+        {%- if custom.operated_by.custom_html %}
+        Operated by: {{ custom.operated_by.custom_html | safe }} |
+        {%- else %}
+        Operated by: <a href="{{ custom.operated_by.url }}">{{ custom.operated_by.name }}</a> |
+        {%- endif %}
 
-      {%- if custom.funded_by.custom_html %}
-      Funded by: {{ custom.funded_by.custom_html | safe }} |
-      {%- else %}
-      Funded by: <a href="{{ custom.funded_by.url }}">{{ custom.funded_by.name }}</a> |
-      {%- endif %}
+        {%- if custom.funded_by.custom_html %}
+        Funded by: {{ custom.funded_by.custom_html | safe }} |
+        {%- else %}
+        Funded by: <a href="{{ custom.funded_by.url }}">{{ custom.funded_by.name }}</a> |
+        {%- endif %}
 
-      {%- if custom.designed_by.custom_html %}
-      Designed by: {{ custom.designed_by.custom_html | safe }}
-      {%- else %}
-      Designed by: <a href="{{ custom.designed_by.url }}">{{ custom.designed_by.name }}</a>
-      {%- endif %}
+        {%- if custom.designed_by.custom_html %}
+        Designed by: {{ custom.designed_by.custom_html | safe }}
+        {%- else %}
+        Designed by: <a href="{{ custom.designed_by.url }}">{{ custom.designed_by.name }}</a>
+        {%- endif %}
+    </div>
+    <div id="login-main" class="container">
+      {% block login_container %}
+      {{ super() }}
+      {% endblock %}
+    </div>
   </div>
   </div>
-  </div>
-  {% block login %}
-  {{ super() }}
-  {% endblock %}
 
   <div class="col-md-8 col-md-offset-2 details">
     <div class="col-md-6">

--- a/templates/login.html
+++ b/templates/login.html
@@ -17,7 +17,7 @@
 <style>
   #login-main {
     display: table;
-    height: 60vh;
+    height: 50vh;
   }
 </style>
 <div class="container login-header" id="home">


### PR DESCRIPTION
https://github.com/2i2c-org/default-hub-homepage/tree/no-homepage-customizations also allows a username and password homepage, but not customizations.

This PR aims to also keep customizations.

I've deployed it to https://workshop.openscapes.2i2c.cloud/hub/login and it looks like:
<img width="1004" alt="Screenshot 2024-05-14 at 18 41 18" src="https://github.com/2i2c-org/default-hub-homepage/assets/7579677/66969b8c-7403-44dc-8929-b4b22eb66039">


Also note that I did a hack where I added the css inside the html otherwise it wasn't being picked up by our hubs and didn't have time to investigate that more. This css just adds the login container slightly up otherwise there's a big akward gap

