### PR TITLE
Support username / password login pages without requiring a branch

### DIFF
--- a/extra-assets/css/login.css
+++ b/extra-assets/css/login.css
@@ -6,6 +6,10 @@
     margin-top: 32px;
 }
 
+#login-main {
+    height: auto;
+}
+
 #login-button {
     margin-top: 32px;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -86,13 +86,9 @@
 
   <div class="row col-md-8 mx-auto details">
     <div class="col-md-6">
-      <big class="details-welcome lead">
+      <p class="details-welcome lead">
       Welcome to the <a href="{{ custom.org.url }}" class="text-decoration-none">{{ custom.org.name }}</a> <strong>2i2c JupyterHub</strong>.
-      </big>
-      <br />
-      <br />
-      This is a pilot service running on open source infrastructure.
-      See <a href="https://2i2c.org/pilot" class="text-decoration-none">the 2i2c Pilot documentation</a> for usage and deployment information.</p>
+      </p>
     </div>
     <div class="col-md-6 details-logos">
       <div class="float-end">

--- a/templates/login.html
+++ b/templates/login.html
@@ -44,7 +44,6 @@
 </script>
 {% else %}
 {{ super() }}
-<script src="{{ static_url('extra-assets/js/login.js') }}"></script>
 {% endif %}
 {% endblock %}
 
@@ -78,35 +77,11 @@
   </div>
   </div>
   <div class="login-container text-center">
-    {% if "interface_selector" in custom and custom["interface_selector"] and (not next or next == "%2Fhub%2F") %}
-    <form>
-      <div class="mb-3">
-        <label class="form-label">After logging in, open:</label>
-        <div class="form-check form-check-inline form-switch">
-          <input class="form-check-input" type="radio" name="interface" value="tree"
-                  {% if "default_url" not in custom or custom["default_url"] == "/tree" %}checked{% endif %} />
-          <label class="form-check-label">Jupyter Notebook</label>
-        </div>
-        <div class="form-check form-check-inline form-switch">
-          <input class="form-check-input" type="radio" name="interface" value="rstudio"
-                  {% if "default_url" in custom and custom["default_url"] == "/rstudio" %}checked{% endif %} />
-          <label class="form-check-label">RStudio</label>
-        </div>
-        <div class="form-check form-check-inline form-switch">
-          <input class="form-check-input" type="radio" name="interface" value="lab"
-                  {% if "default_url" in custom and custom["default_url"] == "/lab" %}checked{% endif %} />
-          <label class="form-check-label">JupyterLab</label>
-        </div>
-      </div>
-    </form>
-    <a role="button" id="login-button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-      Log in to start
-    </a>
-    {% else %}
-    <a role="button" class='btn btn-jupyter btn-lg' href='{{authenticator_login_url}}'>
-      Log in to continue
-    </a>
-    {% endif %}
+    <div id="login-main" class="container">
+      {% block login_container %}
+      {{ super() }}
+      {% endblock %}
+    </div>
   </div>
 
   <div class="row col-md-8 mx-auto details">


### PR DESCRIPTION
- Re-use upstream work to show username / password fields
- Remove note about calling this 'pilot infrastructure'.

Partial re-issue of https://github.com/pangeo-data/pangeo-custom-jupyterhub-templates/pull/7

Ref https://github.com/2i2c-org/infrastructure/issues/6004